### PR TITLE
Run GC before killing the processes

### DIFF
--- a/lib/sidekiq/worker_killer.rb
+++ b/lib/sidekiq/worker_killer.rb
@@ -21,6 +21,8 @@ module Sidekiq
       yield
       # Skip if the max RSS is not exceeded
       return unless @max_rss > 0 && current_rss > @max_rss
+      GC.start(full_mark: true, immediate_sweep: true)
+      return unless @max_rss > 0 && current_rss > @max_rss
       # Launch the shutdown process
       warn "current RSS #{current_rss} of #{identity} exceeds " \
            "maximum RSS #{@max_rss}"


### PR DESCRIPTION
Compared to the restart, running a full GC is a quick and unintrusive option, which might already fix the memory issue. This patch first tells the VM to run a full GC and then check again before initiating the
restart.