### PR TITLE
Add require statement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ gem "sidekiq-worker-killer"
 Add this to your Sidekiq configuration.
 
 ```
+require 'sidekiq/worker_killer'
+
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
     chain.add Sidekiq::WorkerKiller, max_rss: 480


### PR DESCRIPTION
Without requiring `sidekiq/worker_killer`, I get `uninitialized constant Sidekiq::WorkerKiller` error. This fixes it.