### PR TITLE
Add gc option and nil for grace_time option

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://badge.fury.io/rb/sidekiq-worker-killer.svg)](https://badge.fury.io/rb/sidekiq-worker-killer)
 [![CircleCI](https://circleci.com/gh/klaxit/sidekiq-worker-killer.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/klaxit/sidekiq-worker-killer)
 
-[Sidekiq](https://github.com/mperham/sidekiq) is probably the best background processing framework today. At the same time, memory leaks are very hard to tackle in Ruby and we often find ourselves with growing memory consumption. Instead of spending herculean effort fixing leaks, why not kill your processes when they got to be too large ?
+[Sidekiq](https://github.com/mperham/sidekiq) is probably the best background processing framework today. At the same time, memory leaks are very hard to tackle in Ruby and we often find ourselves with growing memory consumption. Instead of spending herculean effort fixing leaks, why not kill your processes when they got to be too large?
 
 Highly inspired by [Gitlab Sidekiq MemoryKiller](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/lib/gitlab/sidekiq_middleware/shutdown.rb) and [Noxa Sidekiq killer](https://github.com/Noxa/sidekiq-killer).
 
@@ -34,9 +34,10 @@ The following options can be overrided.
 | Option | Defaults | Description |
 | ------- | ------- | ----------- |
 | max_rss | 0 MB (disabled) | max RSS in megabytes. Above this, shutdown will be triggered. |
-| grace_time | 900 seconds | when shutdown is triggered, the Sidekiq process will not accept new job and wait at most 15 minutes for running jobs to finish.  |
+| grace_time | 900 seconds | when shutdown is triggered, the Sidekiq process will not accept new job and wait at most 15 minutes for running jobs to finish. If Float::INFINITY specified, will wait forever  |
 | shutdown_wait | 30 seconds | when the grace time expires, still running jobs get 30 seconds to terminate. After that, kill signal is triggered.  |
 | kill_signal | SIGKILL | Signal to use kill Sidekiq process if it doesn't terminate.  |
+| gc | true | Try to run garbage collection before Sidekiq process terminate in case of max_rss exceeded  |
 
 ## Authors
 

--- a/lib/sidekiq/worker_killer.rb
+++ b/lib/sidekiq/worker_killer.rb
@@ -11,18 +11,20 @@ module Sidekiq
     MUTEX = Mutex.new
 
     def initialize(options = {})
-      @max_rss         = (options[:max_rss]         || 0)
-      @grace_time      = (options[:grace_time]      || 15 * 60)
-      @shutdown_wait   = (options[:shutdown_wait]   || 30)
-      @kill_signal     = (options[:kill_signal]     || "SIGKILL")
+      @max_rss         = options.fetch(:max_rss, 0)
+      @grace_time      = options.fetch(:grace_time, 15 * 60)
+      @shutdown_wait   = options.fetch(:shutdown_wait, 30)
+      @kill_signal     = options.fetch(:kill_signal, "SIGKILL")
+      @gc              = options.fetch(:gc, true)
     end
 
     def call(_worker, _job, _queue)
       yield
       # Skip if the max RSS is not exceeded
-      return unless @max_rss > 0 && current_rss > @max_rss
-      GC.start(full_mark: true, immediate_sweep: true)
-      return unless @max_rss > 0 && current_rss > @max_rss
+      return unless @max_rss > 0
+      return unless current_rss > @max_rss
+      GC.start(full_mark: true, immediate_sweep: true) if @gc
+      return unless current_rss > @max_rss
       # Launch the shutdown process
       warn "current RSS #{current_rss} of #{identity} exceeds " \
            "maximum RSS #{@max_rss}"
@@ -61,9 +63,15 @@ module Sidekiq
     def wait_job_finish_in_grace_time
       start = Time.now
       loop do
-        break if start + @grace_time < Time.now || no_jobs_on_quiet_processes?
+        break if grace_time_exceeded?(start)
+        break if no_jobs_on_quiet_processes?
         sleep(1)
       end
+    end
+
+    def grace_time_exceeded?(start)
+      return false if @grace_time == Float::INFINITY
+      start + @grace_time < Time.now
     end
 
     def no_jobs_on_quiet_processes?


### PR DESCRIPTION
Good evening and thanks for useful gem!

I've got two special use cases for the gem: restart as soon as possible, and wait all jobs to finish without timeout. So I implemented `gc: false` option and `grace_time: nil`.

How it looks like? What should I change?