### PR TITLE
Add Klaxit specific global rubocop rules 📏

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ log
 pkg/*
 rdoc
 tmp
-.DS_STORE
 .byebug_history
 .rvmrc
 .ruby-version
@@ -17,5 +16,5 @@ vendor/bundle
 .bundle
 *.gem
 
-## IDEs
-.idea/
+## KLAXIT
+.rubocop-*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,43 +1,9 @@
-# Override default Rubocop confg
-# See https://github.com/bbatsov/rubocop
+# Override Klaxit remote Rubocop config
+# See https://github.com/klaxit/ruby/rubocop.yml
+inherit_from:
+  - https://raw.githubusercontent.com/klaxit/ruby/master/rubocop.yml
 
 AllCops:
   Exclude:
-    - "spec/**/*"
+    - 'spec/**/*'
 
-Layout/DotPosition:
-  EnforcedStyle: leading
-
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: space
-  EnforcedStyleForEmptyBraces: no_space
-
-Style/HashSyntax:
-  EnforcedStyle: ruby19_no_mixed_keys
-  UseHashRocketsWithSymbolValues: false
-  PreferHashRocketsForNonAlnumEndingSymbols: false
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-  ConsistentQuotesInMultiline: true
-
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
-
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/PercentLiteralDelimiters:
-  PreferredDelimiters:
-    default: ()
-    '%i': '()'
-    '%I': '()'
-    '%r': '()'
-    '%w': '()'
-    '%W': '()'
-
-##################### Metrics ####################
-
-Metrics/MethodLength:
-  CountComments: false  # count full line comments?
-  Max: 20

--- a/Makefile
+++ b/Makefile
@@ -5,3 +5,6 @@ console:
 
 test:
 	bundle exec rspec spec
+
+lint:
+	bundle exec rubocop

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 
 Highly inspired by [Gitlab Sidekiq MemoryKiller](https://gitlab.com/gitlab-org/gitlab-ce/blob/master/lib/gitlab/sidekiq_middleware/shutdown.rb) and [Noxa Sidekiq killer](https://github.com/Noxa/sidekiq-killer).
 
+quick-refs: [install](#install) | [usage](#usage) | [available options](#available-options) | [development](#development)
+
 ## Install
 Use [Bundler](http://bundler.io/)
-```
+```ruby
 gem "sidekiq-worker-killer"
 ```
 
@@ -17,7 +19,7 @@ gem "sidekiq-worker-killer"
 
 Add this to your Sidekiq configuration.
 
-```
+```ruby
 require 'sidekiq/worker_killer'
 
 Sidekiq.configure_server do |config|
@@ -27,7 +29,7 @@ Sidekiq.configure_server do |config|
 end
 ```
 
-# Available options
+## Available options
 
 The following options can be overrided.
 
@@ -37,6 +39,19 @@ The following options can be overrided.
 | grace_time | 900 seconds | when shutdown is triggered, the Sidekiq process will not accept new job and wait at most 15 minutes for running jobs to finish.  |
 | shutdown_wait | 30 seconds | when the grace time expires, still running jobs get 30 seconds to terminate. After that, kill signal is triggered.  |
 | kill_signal | SIGKILL | Signal to use kill Sidekiq process if it doesn't terminate.  |
+
+## Development
+
+Pull Requests are very welcome!
+
+There are tasks that may help you along the way in a makefile:
+
+```bash
+make console # Loads the whole stack in an IRB session.
+make test # Run tests.
+make lint # Run rubocop linter.
+```
+Please make sure that you have tested your code carefully before opening a PR, and make sure as well that you have no style issues.
 
 ## Authors
 

--- a/lib/sidekiq/worker_killer.rb
+++ b/lib/sidekiq/worker_killer.rb
@@ -2,103 +2,104 @@ require "get_process_mem"
 require "sidekiq"
 require "sidekiq/util"
 
-module Sidekiq
-  # Sidekiq server middleware. Kill worker when the RSS memory exceeds limit
-  # after a given grace time.
-  class WorkerKiller
-    include Sidekiq::Util
+# Sidekiq server middleware. Kill worker when the RSS memory exceeds limit
+# after a given grace time.
+class Sidekiq::WorkerKiller
+  include Sidekiq::Util
 
-    MUTEX = Mutex.new
+  MUTEX = Mutex.new
 
-    def initialize(options = {})
-      @max_rss         = (options[:max_rss]         || 0)
-      @grace_time      = (options[:grace_time]      || 15 * 60)
-      @shutdown_wait   = (options[:shutdown_wait]   || 30)
-      @kill_signal     = (options[:kill_signal]     || "SIGKILL")
+  def initialize(options = {})
+    @max_rss         = (options[:max_rss]         || 0)
+    @grace_time      = (options[:grace_time]      || 15 * 60)
+    @shutdown_wait   = (options[:shutdown_wait]   || 30)
+    @kill_signal     = (options[:kill_signal]     || "SIGKILL")
+  end
+
+  def call(_worker, _job, _queue)
+    yield
+    # Skip if the max RSS is not exceeded
+    return unless @max_rss > 0 && current_rss > @max_rss
+
+    GC.start(full_mark: true, immediate_sweep: true)
+    return unless @max_rss > 0 && current_rss > @max_rss
+
+    # Launch the shutdown process
+    warn "current RSS #{current_rss} of #{identity} exceeds " \
+         "maximum RSS #{@max_rss}"
+    request_shutdown
+  end
+
+  private
+
+  def request_shutdown
+    # In another thread to allow undelying job to finish
+    Thread.new do
+      # Only if another thread is not already
+      # shutting down the Sidekiq process
+      shutdown if MUTEX.try_lock
     end
+  end
 
-    def call(_worker, _job, _queue)
-      yield
-      # Skip if the max RSS is not exceeded
-      return unless @max_rss > 0 && current_rss > @max_rss
-      GC.start(full_mark: true, immediate_sweep: true)
-      return unless @max_rss > 0 && current_rss > @max_rss
-      # Launch the shutdown process
-      warn "current RSS #{current_rss} of #{identity} exceeds " \
-           "maximum RSS #{@max_rss}"
-      request_shutdown
+  def shutdown
+    warn "sending #{quiet_signal} to #{identity}"
+    signal(quiet_signal, pid)
+
+    warn "shutting down #{identity} in #{@grace_time} seconds"
+    wait_job_finish_in_grace_time
+
+    warn "sending SIGTERM to #{identity}"
+    signal("SIGTERM", pid)
+
+    warn "waiting #{@shutdown_wait} seconds before sending " \
+          "#{@kill_signal} to #{identity}"
+    sleep(@shutdown_wait)
+
+    warn "sending #{@kill_signal} to #{identity}"
+    signal(@kill_signal, pid)
+  end
+
+  def wait_job_finish_in_grace_time
+    start = Time.now
+    loop do
+      break if start + @grace_time < Time.now || no_jobs_on_quiet_processes?
+
+      sleep(1)
     end
+  end
 
-    private
-
-    def request_shutdown
-      # In another thread to allow undelying job to finish
-      Thread.new do
-        # Only if another thread is not already
-        # shutting down the Sidekiq process
-        shutdown if MUTEX.try_lock
-      end
+  def no_jobs_on_quiet_processes?
+    Sidekiq::ProcessSet.new.each do |process|
+      return false if !process["busy"] == 0 && process["quiet"]
     end
+    true
+  end
 
-    def shutdown
-      warn "sending #{quiet_signal} to #{identity}"
-      signal(quiet_signal, pid)
+  def current_rss
+    ::GetProcessMem.new.mb
+  end
 
-      warn "shutting down #{identity} in #{@grace_time} seconds"
-      wait_job_finish_in_grace_time
+  def signal(signal, pid)
+    ::Process.kill(signal, pid)
+  end
 
-      warn "sending SIGTERM to #{identity}"
-      signal("SIGTERM", pid)
+  def pid
+    ::Process.pid
+  end
 
-      warn "waiting #{@shutdown_wait} seconds before sending " \
-            "#{@kill_signal} to #{identity}"
-      sleep(@shutdown_wait)
+  def identity
+    "#{hostname}:#{pid}"
+  end
 
-      warn "sending #{@kill_signal} to #{identity}"
-      signal(@kill_signal, pid)
+  def quiet_signal
+    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("5.0")
+      "TSTP"
+    else
+      "USR1"
     end
+  end
 
-    def wait_job_finish_in_grace_time
-      start = Time.now
-      loop do
-        break if start + @grace_time < Time.now || no_jobs_on_quiet_processes?
-        sleep(1)
-      end
-    end
-
-    def no_jobs_on_quiet_processes?
-      Sidekiq::ProcessSet.new.each do |process|
-        return false if !process["busy"].zero? && process["quiet"]
-      end
-      true
-    end
-
-    def current_rss
-      ::GetProcessMem.new.mb
-    end
-
-    def signal(signal, pid)
-      ::Process.kill(signal, pid)
-    end
-
-    def pid
-      ::Process.pid
-    end
-
-    def identity
-      "#{hostname}:#{pid}"
-    end
-
-    def quiet_signal
-      if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new("5.0")
-        "TSTP"
-      else
-        "USR1"
-      end
-    end
-
-    def warn(msg)
-      Sidekiq.logger.warn(msg)
-    end
+  def warn(msg)
+    Sidekiq.logger.warn(msg)
   end
 end

--- a/lib/sidekiq/worker_killer/version.rb
+++ b/lib/sidekiq/worker_killer/version.rb
@@ -1,5 +1,7 @@
+# rubocop:disable Style/ClassAndModuleChildren
 module Sidekiq
   class WorkerKiller
     VERSION = "0.3.0".freeze
   end
 end
+# rubocop:enable Style/ClassAndModuleChildren

--- a/sidekiq-worker-killer.gemspec
+++ b/sidekiq-worker-killer.gemspec
@@ -1,5 +1,4 @@
-# -*- encoding: utf-8 -*-
-$LOAD_PATH.push File.expand_path("../lib", __FILE__)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 require "sidekiq/worker_killer/version"
 
 Gem::Specification.new do |s|
@@ -19,6 +18,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("get_process_mem", "~> 0.2.1")
   s.add_runtime_dependency("sidekiq", ">= 3")
 
-  s.add_development_dependency("rubocop", "~> 0.49.1")
   s.add_development_dependency("rspec", "~> 3.5")
+  s.add_development_dependency("rubocop", "~> 0.49.1")
 end


### PR DESCRIPTION
We've made a global Rubocop configuration a few month ago. However this repo doesn't take advantage of it yet.

I've made the change, linted what needed to be linted. And also updated [README] and `.gitignore` accordingly.


[README]: https://github.com/klaxit/sidekiq-worker-killer/blob/0074fa81281f50f09281d174a57d45bdd477464f/README.md