### PR TITLE
Fix grace time not getting honored

### DIFF
--- a/lib/sidekiq/worker_killer.rb
+++ b/lib/sidekiq/worker_killer.rb
@@ -76,14 +76,7 @@ class Sidekiq::WorkerKiller
 
   def no_jobs_on_quiet_processes?
     Sidekiq::ProcessSet.new.each do |process|
-      return false if !process["busy"].zero? && process["quiet"]
-    end
-    true
-  end
-
-  def no_jobs_on_quiet_processes?
-    Sidekiq::ProcessSet.new.each do |process|
-      return false if !process["busy"] == 0 && process["quiet"]
+      return false if process["busy"] != 0 && process["quiet"] == "true"
     end
     true
   end

--- a/spec/sidekiq/worker_killer_spec.rb
+++ b/spec/sidekiq/worker_killer_spec.rb
@@ -59,6 +59,41 @@ describe Sidekiq::WorkerKiller do
         2.times.map{ subject.send(:request_shutdown) }.each(&:join)
       end
     end
+
+    context "grace time is 5 seconds" do
+      subject{ described_class.new(max_rss: 2, grace_time: 5.0, shutdown_wait: 0) }
+      it "should wait the specified grace time before calling shutdown" do
+        # there are busy jobs that will not terminate within the grace time
+        allow(subject).to receive(:no_jobs_on_quiet_processes?).and_return(false)
+
+        shutdown_request_time     = nil
+        shutdown_time             = nil
+
+        # replace the original #request_shutdown to track
+        # when the shutdown is requested
+        original_request_shutdown = subject.method(:request_shutdown)
+        allow(subject).to receive(:request_shutdown) do
+          shutdown_request_time= Time.now
+          original_request_shutdown.call
+        end
+
+        # track when the SIGTERM signal is sent
+        allow(Process).to receive(:kill) do |*args|
+          shutdown_time = Time.now if args[0] == 'SIGTERM'
+        end
+
+        allow(subject).to receive(:pid).and_return(99)
+
+        subject.send(:request_shutdown).join
+
+        elapsed_time = shutdown_time - shutdown_request_time
+
+        # the elapsed time beetween shutdown request and the actual
+        # shutdown signal should be greater than the specificed grace_time
+        expect(elapsed_time).to be >= 5.0
+      end
+    end
+
     context "grace time is Float::INFINITY" do
       subject{ described_class.new(max_rss: 2, grace_time: Float::INFINITY, shutdown_wait: 0) }
       it "call signal only on jobs" do


### PR DESCRIPTION
Hey,

This pull request should resolve #7.
I applied the fix proposed by @BuonOmo verbatim.
I also added a test checking if the grace time has elapsed before busy sidekiq processes receive the shutdown signal.

Please take a look at the changes and let me know if you want to change anything.
