### PR TITLE
This feature adds skip_shutdown_if option to be defined

### DIFF
--- a/spec/sidekiq/worker_killer_spec.rb
+++ b/spec/sidekiq/worker_killer_spec.rb
@@ -29,6 +29,35 @@ describe Sidekiq::WorkerKiller do
         expect(GC).to receive(:start).with(full_mark: true, immediate_sweep: true)
         subject.call(worker, job, queue){}
       end
+
+      context "when skip_shutdown_if is given" do
+        subject{ described_class.new(max_rss: 2, skip_shutdown_if: skip_shutdown_proc) }
+
+        context "and skip_shutdown_if is a proc" do
+          let(:skip_shutdown_proc) { proc { |worker| true } }
+          it "should NOT request shutdown" do
+            expect(subject).not_to receive(:request_shutdown)
+            subject.call(worker, job, queue){}
+          end
+        end
+
+        context "and skip_shutdown_if is a lambda" do
+          let(:skip_shutdown_proc) { ->(worker, job, queue) { true } }
+          it "should NOT request shutdown" do
+            expect(subject).not_to receive(:request_shutdown)
+            subject.call(worker, job, queue){}
+          end
+        end
+
+        context "and skip_shutdown_if returns false" do
+          let(:skip_shutdown_proc) { proc { |worker, job, queue| false } }
+          it "should still request shutdown" do
+            expect(subject).to receive(:request_shutdown)
+            subject.call(worker, job, queue){}
+          end
+        end
+      end
+
       context "when gc is false" do
         subject{ described_class.new(max_rss: 2, gc: false) }
         it "should not call garbage collect" do

--- a/spec/sidekiq/worker_killer_spec.rb
+++ b/spec/sidekiq/worker_killer_spec.rb
@@ -30,7 +30,7 @@ describe Sidekiq::WorkerKiller do
         subject.call(worker, job, queue){}
       end
 
-      context "when skip_shutdown_if is given" do
+      context "and skip_shutdown_if is given" do
         subject{ described_class.new(max_rss: 2, skip_shutdown_if: skip_shutdown_proc) }
 
         context "and skip_shutdown_if is a proc" do
@@ -51,6 +51,14 @@ describe Sidekiq::WorkerKiller do
 
         context "and skip_shutdown_if returns false" do
           let(:skip_shutdown_proc) { proc { |worker, job, queue| false } }
+          it "should still request shutdown" do
+            expect(subject).to receive(:request_shutdown)
+            subject.call(worker, job, queue){}
+          end
+        end
+
+        context "and skip_shutdown_if returns nil" do
+          let(:skip_shutdown_proc) { proc { |worker, job, queue| nil } }
           it "should still request shutdown" do
             expect(subject).to receive(:request_shutdown)
             subject.call(worker, job, queue){}


### PR DESCRIPTION
Hello everyone!

Thanks for this gem. Very useful.

I just came across an issue where I don't want to request_shutdown even though the worker exceeds max RSS. We've got, for example, a Worker class that may exceed RSS but it can run for hours. So rather than setting `grace_time` to hours or Float::INFINITY, I've added a `skip_shutdown_if` option which can receive a lambda/proc.

```ruby
Sidekiq.configure_server do |config|
  Rails.logger = Sidekiq::Logging.logger

  config.server_middleware do |chain|
    max_rss = ENV['SIDEKIQ_MAX_RSS'] || 100
    chain.add Sidekiq::CustomWorkerKiller, max_rss: max_rss,
      skip_shutdown_if: proc { |worker| worker.class.name == 'LongWorker' }
  end
end
```

Let me know what you guys think.

Thank you in advance!
