### PR TITLE
Add `on_shutdown` hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following options can be overridden.
 | kill_signal | SIGKILL | Signal to use to kill Sidekiq process if it doesn't stop. |
 | gc | true | Try to run garbage collection before Sidekiq process stops in case of exceeded max_rss. |
 | skip_shutdown_if | proc {false} | Executes a block of code after max_rss exceeds but before requesting shutdown. |
+| on_shutdown | proc | Executes a block of code before just before requesting shutdown. This can be used to send custom logs or metrics to external services. |
 
 *skip_shutdown_if* is expected to return anything other than `false` or `nil` to skip shutdown.
 

--- a/lib/sidekiq/worker_killer.rb
+++ b/lib/sidekiq/worker_killer.rb
@@ -36,6 +36,9 @@ class Sidekiq::WorkerKiller
   # @option options [Proc] skip_shutdown_if
   #   Executes a block of code after max_rss exceeds but before requesting
   #   shutdown. (default: `proc {false}`)
+  # @option options [Proc] on_shutdown
+  #   Executes a block of code right before a shutdown happens.
+  #   (default: `proc`)
   def initialize(options = {})
     @max_rss         = options.fetch(:max_rss, 0)
     @grace_time      = options.fetch(:grace_time, 15 * 60)
@@ -43,6 +46,7 @@ class Sidekiq::WorkerKiller
     @kill_signal     = options.fetch(:kill_signal, "SIGKILL")
     @gc              = options.fetch(:gc, true)
     @skip_shutdown   = options.fetch(:skip_shutdown_if, proc { false })
+    @on_shutdown     = options.fetch(:on_shutdown, proc)
   end
 
   # @param [String, Class] worker_class
@@ -68,17 +72,23 @@ class Sidekiq::WorkerKiller
 
     warn "current RSS #{current_rss} of #{identity} exceeds " \
          "maximum RSS #{@max_rss}"
+
+    run_shutdown_hook
     request_shutdown
   end
 
   private
+
+  def run_shutdown_hook(worker, job, queue)
+    @on_shutdown.respond_to?(:call) && @on_shutdown.call(worker, job, queue)
+  end
 
   def skip_shutdown?(worker, job, queue)
     @skip_shutdown.respond_to?(:call) && @skip_shutdown.call(worker, job, queue)
   end
 
   def request_shutdown
-    # In another thread to allow undelying job to finish
+    # In another thread to allow underlying job to finish
     Thread.new do
       # Only if another thread is not already
       # shutting down the Sidekiq process
@@ -132,7 +142,7 @@ class Sidekiq::WorkerKiller
   end
 
   def identity
-    config[:identity] || config["identity"]
+      config[:identity] || config["identity"]
   end unless method_defined?(:identity)
 
   def warn(msg)


### PR DESCRIPTION
This adds an `on_shutdown` option that allows the user to execute an arbitrary block of code right before shutdown happens. This can be useful to allow for custom logging/metrics to be sent when a misbehaving process is caught. It also adds simple tests to check that the hook is called.

Resolves #22.